### PR TITLE
build: remove audit step from ci

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Install
         run: yarn
 
-      - name: Audit
-        run: yarn audit
-
       - name: Build
         run: yarn run build
 


### PR DESCRIPTION
too many false positives and dependabot automatically submits PRs about these issues