### PR TITLE
feat: allow keys to be dropped from log lines before insertion

### DIFF
--- a/src/config/config.elastic.ts
+++ b/src/config/config.elastic.ts
@@ -64,6 +64,8 @@ export const LogShipperConfigGroupValidator = z.object({
   drop: z.boolean().optional(),
   /** Index pattern prefix */
   prefix: z.string().optional(),
+  /** Drop keys from the log line before inserting into elastic */
+  dropKeys: z.array(z.string()).optional(),
   /**
    * How should this log group be indexed daily or monthly
    * @default parent.index

--- a/src/shipper/__tests__/handler.test.ts
+++ b/src/shipper/__tests__/handler.test.ts
@@ -1,7 +1,10 @@
 'use strict';
 import { expect } from 'chai';
-import { eventTime } from '../../shipper/log';
-import { splitJsonString } from '../../shipper/log.handle';
+import sinon from 'sinon';
+import { Log } from '../../logger';
+import { eventTime, LogObject } from '../../shipper/log';
+import { processCloudWatchData, splitJsonString } from '../../shipper/log.handle';
+import { LogShipper } from '../shipper.config';
 
 describe('splitJSONString', () => {
   it('works without a callback', () => {
@@ -9,6 +12,73 @@ describe('splitJSONString', () => {
     expect(result).to.be.an('Array');
     expect(result).to.have.lengthOf(3);
     expect(result).to.deep.equal(['{a}', '{b}', '{c}']);
+  });
+});
+
+describe('processData', () => {
+  let shipper: LogShipper;
+  const sandbox = sinon.createSandbox();
+
+  const logLine = {
+    owner: '123',
+    logGroup: '/aws/lambda/foo',
+    logStream: 'foo-bar',
+    subscriptionFilters: [],
+    messageType: 'something',
+    logEvents: [{ id: '1', timestamp: Date.now(), message: JSON.stringify({ key: 'value', toDrop: 'something' }) }],
+  };
+
+  beforeEach(() => {
+    shipper = new LogShipper({} as any);
+    shipper.config.accounts = [
+      {
+        id: '123',
+        name: 'fake-config',
+        logGroups: [
+          {
+            filter: '/aws/lambda/foo**',
+            prefix: 'foo-index',
+            index: 1,
+          },
+        ],
+      },
+    ];
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should save a log line', async () => {
+    const saveStub = sandbox.stub(shipper.es, 'save');
+    await processCloudWatchData(shipper, logLine, Log);
+    expect(saveStub.callCount).equal(1);
+    expect(shipper.es.body.length).eq(2);
+    const firstIndexLine = shipper.es.body[0] as any;
+    expect(firstIndexLine.index._index).equal('foo-index-123-' + new Date().toISOString().substring(0, 10));
+    const firstLogLine = shipper.es.body[1] as LogObject;
+    expect(firstLogLine['key']).eq('value');
+    expect(firstLogLine['toDrop']).eq('something');
+  });
+
+  it('should drop keys', async () => {
+    const saveStub = sandbox.stub(shipper.es, 'save');
+    shipper.config.accounts[0].logGroups[0].dropKeys = ['toDrop'];
+
+    await processCloudWatchData(shipper, logLine, Log);
+    expect(saveStub.callCount).equal(1);
+    expect(shipper.es.body.length).eq(2);
+    const firstLogLine = shipper.es.body[1] as LogObject;
+    expect(firstLogLine['key']).eq('value');
+    expect(firstLogLine['toDrop']).eq(undefined);
+  });
+
+  it('should drop indexes', async () => {
+    const saveStub = sandbox.stub(shipper.es, 'save');
+    shipper.config.accounts[0].logGroups[0].drop = true;
+    await processCloudWatchData(shipper, logLine, Log);
+    expect(saveStub.callCount).equal(0);
+    expect(shipper.es.body.length).eq(0);
   });
 });
 

--- a/src/shipper/log.handle.ts
+++ b/src/shipper/log.handle.ts
@@ -59,11 +59,15 @@ export async function processCloudWatchData(
   for (const logLine of c.logEvents) {
     const logObject = getLogObject(c, logLine, source);
     if (logObject == null) continue;
-
     if (streamTags.length > 0) logObject['@tags'] = streamTags.concat(logObject['@tags'] ?? []);
 
     // Trim out empty tags
-    if (logObject['@tags']?.length === 0) logObject['@tags'] = undefined;
+    if (logObject['@tags']?.length === 0) delete logObject['@tags'];
+
+    // Remove any keys that should be dropped
+    if (Array.isArray(streamConfig.dropKeys)) {
+      for (const key of streamConfig.dropKeys) delete logObject[key];
+    }
 
     logShipper.es.queue(logObject, prefix, index);
   }


### PR DESCRIPTION
this adds "dropKeys" to stream configuration that will remove the keys from the log object before inserting the line into elastic search