### PR TITLE
chore: Auto-merge patch dependencies.

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -8,3 +8,6 @@ automerge_label = "automerge 🚀"
 [merge.automerge_dependencies]
 versions = ["patch"]
 usernames = ["dependabot"]
+
+[approve]
+auto_approve_usernames = ["dependabot"]

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,3 +4,7 @@ version = 1
 [merge]
 method = "squash"
 automerge_label = "automerge 🚀"
+
+[merge.automerge_dependencies]
+versions = ["patch"]
+usernames = ["dependabot"]


### PR DESCRIPTION
Dependency patch upgrades shouldn't need human intervention to merge.