### PR TITLE
feat: remove account id from index name

### DIFF
--- a/src/__tests__/integration/handler.test.ts
+++ b/src/__tests__/integration/handler.test.ts
@@ -138,7 +138,7 @@ describe('HandlerIntegration', () => {
     const firstLog = getLog(0);
     const indexInsert = shipper.getElastic(fakeAccount).indexes.get(firstLog['@id']);
 
-    expect(indexInsert).eq('@logGroup-111111111111-2019-10-25'); // Daily index with @logGroup prefix
+    expect(indexInsert).eq('@logGroup-2019-10-25'); // Daily index with @logGroup prefix
     expect(firstLog['@tags']).deep.eq(['@account', '@logGroup', 'Lambda log']);
   });
 
@@ -154,7 +154,7 @@ describe('HandlerIntegration', () => {
     const firstLog = getLog(0);
     const indexInsert = shipper.getElastic(fakeAccount).indexes.get(firstLog['@id']);
 
-    expect(indexInsert).eq('@account-111111111111-2019-10-24'); // Weekly index with @account prefix
+    expect(indexInsert).eq('@account-2019-10-24'); // Weekly index with @account prefix
     expect(firstLog['@tags']).deep.eq(['@account', 'Lambda log']);
   });
 });

--- a/src/shipper/__tests__/elastic.test.ts
+++ b/src/shipper/__tests__/elastic.test.ts
@@ -17,50 +17,50 @@ describe('ElasticSearch', () => {
   it('should create monthly index names', () => {
     const es = new ElasticSearch('');
     const indexName = es.getIndexName(makeLog('2019-10-12T15'), 'prefix', 'monthly');
-    expect(indexName).to.equal('prefix-1234-2019-10');
+    expect(indexName).to.equal('prefix-2019-10');
 
     const indexNameB = es.getIndexName(makeLog('2019-10-13T15'), 'prefix', 'monthly');
-    expect(indexNameB).to.equal('prefix-1234-2019-10');
+    expect(indexNameB).to.equal('prefix-2019-10');
   });
 
   it('should create yearly index names', () => {
     const es = new ElasticSearch('');
     const indexName = es.getIndexName(makeLog('2019-10-12T15'), 'prefix', 'yearly');
-    expect(indexName).to.equal('prefix-1234-2019');
+    expect(indexName).to.equal('prefix-2019');
 
     const indexNameB = es.getIndexName(makeLog('2019-10-13T15'), 'prefix', 'yearly');
-    expect(indexNameB).to.equal('prefix-1234-2019');
+    expect(indexNameB).to.equal('prefix-2019');
   });
 
   it('should create daily index names when DAILY_INDEX is true', () => {
     const es = new ElasticSearch('');
     const indexName = es.getIndexName(makeLog('2019-10-12T15'), 'prefix', 'daily');
-    expect(indexName).to.equal('prefix-1234-2019-10-12');
+    expect(indexName).to.equal('prefix-2019-10-12');
 
     const indexNameB = es.getIndexName(makeLog('2019-10-13T15'), 'prefix', 'daily');
-    expect(indexNameB).to.equal('prefix-1234-2019-10-13');
+    expect(indexNameB).to.equal('prefix-2019-10-13');
   });
 
   it('should create weekly index names', () => {
     const es = new ElasticSearch('');
 
-    expect(es.getIndexName(makeLog('2019-10-05T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-03');
-    expect(es.getIndexName(makeLog('2019-10-06T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-03');
-    expect(es.getIndexName(makeLog('2019-10-07T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-03');
-    expect(es.getIndexName(makeLog('2019-10-16T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-10');
-    expect(es.getIndexName(makeLog('2019-10-16T23:59:59.999Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-10');
-    expect(es.getIndexName(makeLog('2019-10-17T00:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-1234-2019-10-17');
+    expect(es.getIndexName(makeLog('2019-10-05T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-03');
+    expect(es.getIndexName(makeLog('2019-10-06T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-03');
+    expect(es.getIndexName(makeLog('2019-10-07T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-03');
+    expect(es.getIndexName(makeLog('2019-10-16T15:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-10');
+    expect(es.getIndexName(makeLog('2019-10-16T23:59:59.999Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-10');
+    expect(es.getIndexName(makeLog('2019-10-17T00:00:00.000Z'), 'prefix', 'weekly')).to.equal('prefix-2019-10-17');
   });
 
   it('should create numeric index names', () => {
     const es = new ElasticSearch('');
 
-    expect(es.getIndexName(makeLog('2019-10-05T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-1234-2019-10-05');
-    expect(es.getIndexName(makeLog('2019-10-06T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-1234-2019-10-05');
-    expect(es.getIndexName(makeLog('2019-10-07T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-1234-2019-10-07');
+    expect(es.getIndexName(makeLog('2019-10-05T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-2019-10-05');
+    expect(es.getIndexName(makeLog('2019-10-06T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-2019-10-05');
+    expect(es.getIndexName(makeLog('2019-10-07T15:00:00.000Z'), 'prefix', 2)).to.equal('prefix-2019-10-07');
 
-    expect(es.getIndexName(makeLog('2019-10-16T15:00:00.000Z'), 'prefix', 3)).to.equal('prefix-1234-2019-10-14');
-    expect(es.getIndexName(makeLog('2019-10-16T23:59:59.999Z'), 'prefix', 3)).to.equal('prefix-1234-2019-10-14');
-    expect(es.getIndexName(makeLog('2019-10-17T00:00:00.000Z'), 'prefix', 3)).to.equal('prefix-1234-2019-10-17');
+    expect(es.getIndexName(makeLog('2019-10-16T15:00:00.000Z'), 'prefix', 3)).to.equal('prefix-2019-10-14');
+    expect(es.getIndexName(makeLog('2019-10-16T23:59:59.999Z'), 'prefix', 3)).to.equal('prefix-2019-10-14');
+    expect(es.getIndexName(makeLog('2019-10-17T00:00:00.000Z'), 'prefix', 3)).to.equal('prefix-2019-10-17');
   });
 });

--- a/src/shipper/__tests__/handler.test.ts
+++ b/src/shipper/__tests__/handler.test.ts
@@ -63,7 +63,7 @@ describe('processData', () => {
     expect(firstLogLine['toDrop']).eq('something');
 
     const firstIndex = es.indexes.get(firstLogLine['@id']);
-    expect(firstIndex).equal('foo-index-123-' + new Date().toISOString().substring(0, 10));
+    expect(firstIndex).equal('foo-index-' + new Date().toISOString().substring(0, 10));
   });
 
   it('should drop keys', async () => {

--- a/src/shipper/elastic.ts
+++ b/src/shipper/elastic.ts
@@ -110,6 +110,6 @@ export class ElasticSearch {
    */
   getIndexName(logObj: LogObject, prefix: string, indexType: LogShipperConfigIndexDate): string {
     const indexDate = getIndexDate(logObj['@timestamp'], indexType);
-    return `${prefix}-${logObj['@owner']}-${indexDate}`;
+    return `${prefix}-${indexDate}`;
   }
 }


### PR DESCRIPTION
BREAKING_CHANGE: this stops the account id from being included in the es index name by default