### PR TITLE
feat: Dependabot for Docker TDE-963

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: daily
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Important to enable automated updates of dependencies once pinning <https://github.com/linz/elasticsearch-shipper/pull/842> is merged.